### PR TITLE
feat: 新增 get_life_context 公共方法供外部插件调用

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,35 @@ class LifeSchedulerPlugin(Star):
         """插件卸载时清理"""
         self.scheduler.stop()
 
+    async def get_life_context(self) -> dict:
+        """
+        获取生活上下文数据（供 DailySharing 插件调用）
+        返回格式符合 DailySharing 的 _parse_life_data 方法要求
+        """
+        today = datetime.datetime.now()
+        data = self.data_mgr.get(today)
+        
+        if not data:
+            # 尝试生成
+            try:
+                # 注意：这里传入 None 作为 umo，让 generator 使用默认行为
+                data = await self.generator.generate_schedule(today, None)
+            except RuntimeError:
+                return {}
+        
+        if not data or data.status == "failed":
+            return {}
+        
+        # 构建返回格式（与 DailySharing 的 _parse_life_data 兼容）
+        return {
+            "outfit": data.outfit,
+            "schedule": data.schedule,
+            "meta": {
+                "style": data.outfit_style,
+            },
+            "timeline": [],  # 如果有 timeline 数据可以在这里添加
+        }
+
     @filter.on_llm_request()
     async def on_llm_request(self, event: AstrMessageEvent, req: ProviderRequest):
         """System Prompt 注入"""


### PR DESCRIPTION
## 问题背景
当前插件仅通过 `on_llm_request` 钩子实现日程的被动注入，缺少供外部插件主动获取结构化日程数据的公共 API。

## 现状
daily_sharing 插件为实现「日程主导」的场景优先级逻辑，已在代码中适配 `get_life_context()` 方法调用，但因本插件未实现该方法，导致 life_context 恒为 None，联动功能静默失效。

## 解决方案
新增 `get_life_context()` 异步方法：
1. 获取当日缓存日程，无缓存时尝试实时生成
2. 返回标准化字典结构，兼容下游插件解析逻辑
3. 异常场景返回空字典，保证调用方容错

## 兼容性
- 仅新增方法，不修改任何现有逻辑
- on_llm_request 钩子、原有命令功能不受影响