### PR TITLE
默认参考会话来源兜底功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install holidays APScheduler
 | `重写日程 <补充要求>` | 管理员 | 带补充要求重新生成，例如：`重写日程 今天穿黑色连衣裙，安排一个下午茶` |
 | `日程时间 <HH:MM>` | 管理员 | 设置每日自动生成时间 |
 
-别名：`life show`、`life renew`、`life time`
+别名：`life show`、`life renew`、`life time`、`life umo`
 
 ## 配置项
 
@@ -35,6 +35,7 @@ pip install holidays APScheduler
 | `schedule_time` | string | `07:00` | 每日自动生成日程的时间 |
 | `reference_history_days` | int | `3` | 生成时参考的历史日程天数 (1-7) |
 | `reference_recent_count` | int | `10` | 生成时参考的近期会话数量，0 表示不参考 |
+| `default_reference_umo` | string | `""` | 默认参考会话来源，用于定时生成日程或未指定会话来源时作为兜底参考 |
 | `pool` | object | - | 创意池，每次生成随机选取 |
 | `prompt_template` | text | - | LLM 生成日程的 Prompt 模板 |
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -26,6 +26,12 @@
     },
     "default": 10
   },
+  "default_reference_umo": {
+    "description": "默认参考会话来源",
+    "hint": "留空则不使用默认参考会话。配置后，会作为定时生成日程或未指定会话来源时的兜底参考会话。填写格式：<bot>:<GroupMessage|FriendMessage>:id，例如 bot:GroupMessage:123456789。",
+    "type": "string",
+    "default": ""
+  },
   "llm_provider": {
     "description": "指定生成日程的 LLM 供应商",
     "hint": "留空则使用当前正在使用的 LLM 供应商。",

--- a/core/generator.py
+++ b/core/generator.py
@@ -122,15 +122,25 @@ class SchedulerGenerator:
     async def _collect_context(
         self, data: datetime.datetime, umo: str | None
     ) -> ScheduleContext:
+        effective_umo = self._resolve_reference_umo(umo)
+        logger.debug(f"[LLM] UMO 上下文注入：{effective_umo or '未配置'}")
         return ScheduleContext(
             date_str=data.strftime("%Y年%m月%d日"),
             weekday=self._weekday(data),
             holiday=self._get_holiday_info(data.date()),
             persona_desc=await self._get_persona(),
             history_schedules=self._get_history(data),
-            recent_chats=await self._get_recent_chats(umo),
+            recent_chats=await self._get_recent_chats(effective_umo),
             **self._pick_diversity(data.date()),
         )
+
+    def _resolve_reference_umo(self, umo: str | None) -> str | None:
+        candidate = str(umo or "").strip()
+        if candidate:
+            return candidate
+
+        default_umo = str(self.config.get("default_reference_umo", "") or "").strip()
+        return default_umo or None
 
     def _weekday(self, data):
         return ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"][

--- a/main.py
+++ b/main.py
@@ -31,6 +31,20 @@ class LifeSchedulerPlugin(Star):
         )
         self.scheduler.start()
 
+    def _save_config(self):
+        save_config = getattr(self.config, "save_config", None)
+        if callable(save_config):
+            save_config()
+
+    @staticmethod
+    def _format_reference_umo(umo: str, *, truncate: bool = True) -> str:
+        umo = str(umo or "").strip()
+        if not umo:
+            return "未配置"
+        if not truncate or len(umo) <= 20:
+            return umo
+        return f"{umo[:8]}...{umo[-4:]}（共{len(umo)}字符）"
+
     async def terminate(self):
         """插件卸载时清理"""
         self.scheduler.stop()
@@ -156,3 +170,39 @@ class LifeSchedulerPlugin(Star):
             yield event.plain_result(f"已将每日日程生成时间更新为 {param}。")
         except Exception as e:
             yield event.plain_result(f"设置失败: {e}")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("参考会话", alias={"life umo"})
+    async def life_reference_umo(self, event: AstrMessageEvent, param: str | None = None):
+        """参考会话 [set|show|clear]，设置默认参考会话来源"""
+        action = (param or "set").strip().lower()
+
+        if action in {"", "set"}:
+            umo = str(event.unified_msg_origin or "").strip()
+            if not umo:
+                yield event.plain_result("当前事件没有可保存的会话来源")
+                return
+            self.config["default_reference_umo"] = umo
+            self._save_config()
+            yield event.plain_result(
+                f"已保存默认参考会话：{self._format_reference_umo(umo)}"
+            )
+            return
+
+        if action == "show":
+            umo = str(self.config.get("default_reference_umo", "") or "").strip()
+            if umo:
+                yield event.plain_result(
+                    f"默认参考会话已配置：{self._format_reference_umo(umo, truncate=False)}"
+                )
+            else:
+                yield event.plain_result("默认参考会话未配置")
+            return
+
+        if action == "clear":
+            self.config["default_reference_umo"] = ""
+            self._save_config()
+            yield event.plain_result("已清除默认参考会话")
+            return
+
+        yield event.plain_result("用法：参考会话 [set|show|clear]")

--- a/tests/test_scheduler_behavior.py
+++ b/tests/test_scheduler_behavior.py
@@ -4,6 +4,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 class _Logger:
@@ -86,6 +87,7 @@ def _config():
     return {
         "reference_history_days": 3,
         "reference_recent_count": 0,
+        "default_reference_umo": "",
         "llm_provider": "",
         "pool": {
             "daily_themes": ["探索日"],
@@ -353,6 +355,63 @@ class SchedulerBehaviorTest(unittest.IsolatedAsyncioTestCase):
             select_current_activity(schedule, now=now, wrap_previous_day=False),
             "08:00 起床洗漱",
         )
+
+    async def test_collect_context_uses_default_reference_umo_when_event_missing(self):
+        generator, _ = self._generator()
+        generator.config["default_reference_umo"] = "default-umo"
+
+        seen = {}
+
+        async def fake_get_recent_chats(umo, count=None):
+            seen["umo"] = umo
+            return f"recent:{umo}"
+
+        generator._get_recent_chats = fake_get_recent_chats
+
+        ctx = await generator._collect_context(datetime.datetime(2026, 5, 24), None)
+
+        self.assertEqual(seen["umo"], "default-umo")
+        self.assertEqual(ctx.recent_chats, "recent:default-umo")
+
+    async def test_collect_context_logs_effective_umo(self):
+        generator, _ = self._generator()
+        generator.config["default_reference_umo"] = "default-umo"
+
+        async def fake_get_recent_chats(umo, count=None):
+            return f"recent:{umo}"
+
+        generator._get_recent_chats = fake_get_recent_chats
+
+        with patch("core.generator.logger.debug") as mock_debug:
+            await generator._collect_context(datetime.datetime(2026, 5, 24), None)
+
+        mock_debug.assert_any_call("[LLM] UMO 上下文注入：default-umo")
+
+    async def test_collect_context_prefers_explicit_umo_over_default_reference(self):
+        generator, _ = self._generator()
+        generator.config["default_reference_umo"] = "default-umo"
+
+        seen = {}
+
+        async def fake_get_recent_chats(umo, count=None):
+            seen["umo"] = umo
+            return f"recent:{umo}"
+
+        generator._get_recent_chats = fake_get_recent_chats
+
+        ctx = await generator._collect_context(
+            datetime.datetime(2026, 5, 24), "event-umo"
+        )
+
+        self.assertEqual(seen["umo"], "event-umo")
+        self.assertEqual(ctx.recent_chats, "recent:event-umo")
+
+    async def test_collect_context_keeps_empty_reference_behavior_when_not_configured(self):
+        generator, _ = self._generator()
+
+        ctx = await generator._collect_context(datetime.datetime(2026, 5, 24), None)
+
+        self.assertEqual(ctx.recent_chats, "无近期对话")
 
     def test_character_state_injection_includes_current_activity(self):
         schedule = (


### PR DESCRIPTION
## 概述
为 Life Scheduler 插件增加 `default_reference_umo` 配置项，允许管理员设置一个默认的参考会话来源，在定时自动生成日程或用户未显式指定会话来源时作为兜底参考。

## 变更内容

### 新增配置项 `default_reference_umo`
- 类型：`string`，默认值：`""`（空字符串表示不启用）
- 填写格式：`<bot>:<GroupMessage|FriendMessage>:id`
- 当配置后，会作为定时生成日程或未指定会话来源时的兜底参考会话

### 核心逻辑变更（`core/generator.py`）
- 新增 `_resolve_reference_umo()` 方法：当传入的 `umo` 为空时，回退到 `default_reference_umo` 配置
- `_collect_context()` 改为使用解析后的 `effective_umo` 获取近期聊天记录
- 添加调试日志 `[LLM] UMO 上下文注入：...`

### 新增管理命令（`main.py`）
- `参考会话 set` — 自动从当前消息来源保存为默认参考会话
- `参考会话 show` — 显示当前配置的默认参考会话
- `参考会话 clear` — 清除默认参考会话配置
- 别名：`life umo`

### 测试覆盖
- 当未传入 UMO 时，自动使用 `default_reference_umo`
- 当显式传入 UMO 时，优先使用传入值而非默认值
- 默认值未配置时，行为不受影响（保持原有"无近期对话"）
- 日志输出验证

### 其他
- `_conf_schema.json` 末尾追加换行（EOF 修复）
- `README.md` 添加 `life umo` 别名和配置项说明
