### PR TITLE
Prompt 模板为空时自动回填默认值

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -117,7 +117,7 @@
   },
   "prompt_template": {
     "description": "LLM 生成日程的完整 Prompt 模板",
-    "hint":"插件内部支持格式化的占位符有： {date_str}、{weekday}、{holiday}、{persona_desc}、{daily_theme}、{mood_color}、{outfit_style}、{schedule_type}、{history_schedules}、{recent_chats}，其他占位符默认会被替换为空字符串",
+    "hint":"插件内部支持格式化的占位符有： {date_str}、{weekday}、{holiday}、{persona_desc}、{daily_theme}、{mood_color}、{outfit_style}、{schedule_type}、{history_schedules}、{recent_chats}，其他占位符默认会被替换为空字符串。清空可恢复默认。",
     "type": "text",
     "obvious_hint": true,
     "editor_mode": true,

--- a/core/generator.py
+++ b/core/generator.py
@@ -3,6 +3,8 @@ import datetime
 import json
 import random
 import re
+from functools import lru_cache
+from pathlib import Path
 from dataclasses import asdict, dataclass
 
 from astrbot.api import logger
@@ -43,6 +45,7 @@ class SchedulerGenerator:
         self.context = context
         self.config = config
         self.data_mgr = data_mgr
+        self._ensure_prompt_template_default()
 
         self._gen_lock = asyncio.Lock()
         self._generating = False
@@ -373,7 +376,8 @@ class SchedulerGenerator:
             ctx_dict["outfit_style"] = "用户指定"
             ctx_dict["schedule_type"] = "用户指定"
 
-        tmpl_vars = set(re.findall(r"\{(\w+)\}", self.config["prompt_template"]))
+        template = self._get_prompt_template()
+        tmpl_vars = set(re.findall(r"\{(\w+)\}", template))
         missing = tmpl_vars - ctx_dict.keys()
         if missing:
             logger.warning(
@@ -383,7 +387,7 @@ class SchedulerGenerator:
         # 统一补空值，避免 KeyError
         for k in missing:
             ctx_dict[k] = ""
-        prompt = self.config["prompt_template"].format(**ctx_dict)
+        prompt = self._render_prompt_template(template, ctx_dict)
 
         if extra:
             prompt += (
@@ -406,6 +410,56 @@ class SchedulerGenerator:
             )
 
         return prompt
+
+    def _get_prompt_template(self) -> str:
+        template = str(self.config.get("prompt_template", "") or "").strip()
+        if template:
+            return template
+        return self._default_prompt_template()
+
+    def _ensure_prompt_template_default(self) -> None:
+        template = str(self.config.get("prompt_template", "") or "").strip()
+        if template:
+            return
+
+        default_template = self._default_prompt_template()
+        if not default_template:
+            return
+
+        self.config["prompt_template"] = default_template
+        save_config = getattr(self.config, "save_config", None)
+        if callable(save_config):
+            try:
+                save_config()
+            except Exception:
+                logger.warning("保存默认 prompt_template 失败，已在内存中回填默认值")
+
+    @classmethod
+    def _render_prompt_template(cls, template: str, values: dict[str, object]) -> str:
+        """只替换已知占位符，避免用户在 WebUI 中写坏花括号时直接抛异常。"""
+        placeholder = re.compile(r"\{(\w+)\}")
+        left_token = "\u0000LBRACE\u0000"
+        right_token = "\u0000RBRACE\u0000"
+
+        rendered = template.replace("{{", left_token).replace("}}", right_token)
+
+        def _replace(match: re.Match[str]) -> str:
+            key = match.group(1)
+            return str(values.get(key, ""))
+
+        rendered = placeholder.sub(_replace, rendered)
+        return rendered.replace(left_token, "{").replace(right_token, "}")
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _default_prompt_template() -> str:
+        schema_path = Path(__file__).resolve().parent.parent / "_conf_schema.json"
+        try:
+            data = json.loads(schema_path.read_text(encoding="utf-8"))
+            template = data.get("prompt_template", {}).get("default", "")
+            return str(template or "")
+        except Exception:
+            return ""
 
     async def _call_llm(self, prompt: str, *, sid: str = "life_scheduler_gen") -> str:
         provider_id = self.config.get("llm_provider")

--- a/tests/test_scheduler_behavior.py
+++ b/tests/test_scheduler_behavior.py
@@ -82,6 +82,15 @@ class _Context:
         return self.provider
 
 
+class _ConfigDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.saved = False
+
+    def save_config(self):
+        self.saved = True
+
+
 def _config():
     return {
         "reference_history_days": 3,
@@ -191,6 +200,43 @@ class SchedulerBehaviorTest(unittest.IsolatedAsyncioTestCase):
             manual_extra="穿黑丝和吊带裙",
         )
         self.assertEqual(data.outfit_style, "用户指定")
+
+    def test_prompt_rendering_survives_crlf_and_literal_json_braces(self):
+        generator, _ = self._generator()
+        generator.config["prompt_template"] = (
+            "# Role: Life Scheduler\r\n"
+            "## Output\r\n"
+            "{\r\n"
+            '  "outfit_style": "{outfit_style}",\r\n'
+            '  "outfit": "...",\r\n'
+            '  "schedule": "..."\r\n'
+            "}\r\n"
+            "## Recent Chats\r\n"
+            "{recent_chats}\r\n"
+        )
+
+        prompt = generator._build_prompt(_ctx())
+
+        self.assertIn('"outfit_style": "甜酷混搭风"', prompt)
+        self.assertIn("## Recent Chats", prompt)
+
+    def test_empty_prompt_template_falls_back_to_default(self):
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            data_mgr = ScheduleDataManager(Path(tmp.name) / "schedule_data.json")
+            config = _ConfigDict(_config())
+            config["prompt_template"] = ""
+            generator = SchedulerGenerator(_Context(_Provider([])), config, data_mgr)
+
+            self.assertTrue(config.saved)
+            self.assertIn("# Role: Life Scheduler", config["prompt_template"])
+            prompt = generator._build_prompt(_ctx())
+
+            self.assertIn("# Role: Life Scheduler", prompt)
+            self.assertIn("## Context", prompt)
+            self.assertIn("## Output Format", prompt)
+        finally:
+            tmp.cleanup()
 
     def test_manual_extra_supports_negative_constraints(self):
         generator, _ = self._generator()


### PR DESCRIPTION
## 概述
解决用户在 WebUI 中误清空 `prompt_template` 配置后不便回复默认模板的问题。当 `prompt_template` 为空时，自动从 `_conf_schema.json` 的 `default` 字段恢复默认模板，无需手动找回。

## 变更内容

### 核心逻辑变更（`core/generator.py`）

1. **`_ensure_prompt_template_default()`** — 初始化时检查 `prompt_template` 是否为空，若为空则从 schema 的 `default` 字段回填，并持久化保存
2. **`_get_prompt_template()`** — 统一的模板获取入口，空配置自动兜底
3. **`_render_prompt_template()`** — 安全的字符串渲染方法：
   - 只替换 `{known_placeholder}` 格式的占位符
   - `{{` 和 `}}` 保留为字面花括号 `{` `}`
   - 未知占位符静默替换为空字符串而非抛 KeyError
4. **`_default_prompt_template()`** — 从 `_conf_schema.json` 中读取默认值，带 `lru_cache` 避免重复 I/O
5. **`_build_prompt()`** 调用链改为使用上述安全方法

### 配置说明改进（`_conf_schema.json`）
- `prompt_template` 的 `hint` 字段追加说明：`清空可恢复默认。`

### 测试覆盖
- 空模板自动回填并持久化
- 包含 `\r\n` 和字面 `{}` 的模板渲染正确性
- `_ConfigDict` 辅助类，支持断言 `save_config()` 是否被调用
