### PR TITLE
优化日程注入规则

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- 优化：生活状态默认改为按需注入，并默认追加到用户消息尾部，避免每轮把完整日程写入 `system_prompt` 破坏缓存。
+- 新增：注册 `get_life_schedule_detail` LLM 工具，供模型按需查询当前业务日的详细日程、穿搭和当前状态。
+- 新增：支持 `life_context_injection_mode`、`life_context_injection_target` 和 `life_context_max_schedule_chars` 配置。
+
 ## v2.4.1 - 2026-05-24
 - 修复：手动 `重写日程` 的补充要求不再被随机穿搭风格覆盖，并会校验具体穿搭和活动是否落实。
 - 修复：日常对话注入当前或最近日程活动，减少回答与当天日程冲突。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **日程生成**: 结合日期、节日、历史日程和近期对话，生成拟人化日程
 - **穿搭推荐**: 根据创意池随机选取风格，生成每日穿搭描述
-- **System Prompt 注入**: 自动将当日状态注入 LLM 上下文，Bot 会"记得"自己今天穿了什么、在做什么
+- **按需状态注入**: 默认只在相关对话中注入生活状态，并追加到用户消息尾部，避免每轮改写 System Prompt
 - **当前状态提取**: 对含时间点的日程自动提取当前或最近活动，减少对话中说出与日程冲突的状态
 - **懒加载**: 未到生成时间时，首次对话自动触发生成
 - **补充要求**: 重写日程时可附加自定义要求，让生成更符合预期
@@ -35,6 +35,9 @@ pip install holidays APScheduler
 | `schedule_time` | string | `07:00` | 每日自动生成日程的时间 |
 | `reference_history_days` | int | `3` | 生成时参考的历史日程天数 (1-7) |
 | `reference_recent_count` | int | `10` | 生成时参考的近期会话数量，0 表示不参考 |
+| `life_context_injection_mode` | string | `auto` | 生活状态注入策略：`auto`、`compact`、`full`、`off` |
+| `life_context_injection_target` | string | `user_prompt` | 注入位置：默认追加到用户消息尾部；可设为 `system_prompt` 恢复旧行为 |
+| `life_context_max_schedule_chars` | int | `1200` | `full` 模式或旧式完整日程注入时的最大日程字符数 |
 | `pool` | object | - | 创意池，每次生成随机选取 |
 | `prompt_template` | text | - | LLM 生成日程的 Prompt 模板 |
 
@@ -66,7 +69,11 @@ pip install holidays APScheduler
 
 ## 注入机制
 
-插件在 LLM 请求时自动注入当前状态：
+插件默认使用 `auto` 策略：用户问题涉及日程、穿搭、当前状态、自拍/生图等生活状态时才注入短状态；普通闲聊不注入，也不会触发懒生成。完整日程不再常驻上下文，LLM 需要时可调用 `get_life_schedule_detail` 工具查询。
+
+默认注入到用户消息尾部，保持原始 System Prompt 稳定，利于模型端 prompt cache。若需要旧行为，可把 `life_context_injection_target` 改为 `system_prompt`，或把 `life_context_injection_mode` 改为 `full`。
+
+相关对话中默认只注入类似：
 
 ```xml
 <character_state>
@@ -76,6 +83,10 @@ pip install holidays APScheduler
 今日日程: 上午整理房间，下午去咖啡厅看书...
 </character_state>
 ```
+
+### LLM 工具
+
+插件注册了 `get_life_schedule_detail` 工具，供 LLM 在用户询问完整日程、今天安排、穿搭或当前生活状态时按需查询。工具返回当前业务日的日期、穿搭风格、穿着、当前状态和完整详细日程。
 
 ## 外部插件调用
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -33,6 +33,31 @@
     "_special": "select_provider",
     "default": ""
   },
+  "life_context_injection_mode": {
+    "description": "生活状态注入策略",
+    "hint": "auto：仅在用户问题涉及日程/穿搭/当前状态时注入短状态，完整日程由 LLM 工具按需查询；compact：每次只注入短状态；full：每次注入完整日程（旧行为）；off：关闭注入。",
+    "type": "string",
+    "options": ["auto", "compact", "full", "off"],
+    "default": "auto"
+  },
+  "life_context_injection_target": {
+    "description": "生活状态注入位置",
+    "hint": "默认追加到用户消息尾部，避免修改 system_prompt，提升系统提示词缓存稳定性；如需旧行为可选 system_prompt。",
+    "type": "string",
+    "options": ["user_prompt", "system_prompt"],
+    "default": "user_prompt"
+  },
+  "life_context_max_schedule_chars": {
+    "description": "注入完整日程时的最大字符数",
+    "hint": "只影响注入到 LLM 的完整日程长度，不影响“查看日程”和外部插件读取的完整数据。",
+    "type": "int",
+    "slider": {
+      "min": 200,
+      "max": 5000,
+      "step": 100
+    },
+    "default": 1200
+  },
   "pool": {
     "description": "创意池",
     "hint": "每次生成日程时，各个池会随机选择一个来并入日程生成提示词",

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,16 @@
 import datetime
 import re
 
+LIFE_CONTEXT_INJECTION_MODES = {"off", "auto", "compact", "full"}
+
+_LIFE_CONTEXT_RE = re.compile(
+    r"(日程|行程|安排|计划|现在|当前|正在|在干嘛|做什么|干什么|"
+    r"去哪|哪里|在哪|位置|场景|状态|生活|穿|穿着|穿搭|衣服|服装|鞋|袜|"
+    r"自拍|照片|拍照|生图|画你|画她|你在|你今天|today|schedule|plan|"
+    r"outfit|wear|wearing|doing|where)",
+    re.IGNORECASE,
+)
+
 
 def time_desc(h=None):
     """返回中文时段：深夜/清晨/上午/中午/下午/晚上"""
@@ -20,6 +30,35 @@ def time_desc(h=None):
         if h < 22
         else "深夜"
     )
+
+
+def normalize_life_context_injection_mode(mode: str | None) -> str:
+    mode = str(mode or "auto").strip().lower()
+    return mode if mode in LIFE_CONTEXT_INJECTION_MODES else "auto"
+
+
+def life_context_injection_policy(text: str, mode: str | None) -> tuple[bool, bool]:
+    """Return (should_inject, include_full_schedule)."""
+    mode = normalize_life_context_injection_mode(mode)
+    if mode == "off":
+        return False, False
+    if mode == "full":
+        return True, True
+    if mode == "compact":
+        return True, False
+
+    text = str(text or "")
+    if not _LIFE_CONTEXT_RE.search(text):
+        return False, False
+    return True, False
+
+
+def _clip_text(text: str, max_chars: int | None) -> str:
+    text = str(text or "").strip()
+    if not max_chars or max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "...（已截断，可用“查看日程”获取完整日程）"
+
 
 def parse_schedule_time(schedule_time: str | None) -> tuple[int, int]:
     schedule_time = str(schedule_time or "00:00")
@@ -100,6 +139,8 @@ def build_character_state_injection(
     *,
     now: datetime.datetime | None = None,
     business_now: datetime.datetime | None = None,
+    include_schedule: bool = True,
+    max_schedule_chars: int | None = None,
 ) -> str:
     """Build the system prompt fragment injected into normal LLM requests."""
     now = now or datetime.datetime.now()
@@ -109,17 +150,81 @@ def build_character_state_injection(
         now=now,
         wrap_previous_day=business_now.date() < now.date(),
     )
-    current_state = current_activity or "未解析到具体时间点，请按今日日程整体保持一致"
+    if current_activity:
+        current_state = current_activity
+    elif include_schedule:
+        current_state = "未解析到具体时间点，请按今日日程整体保持一致"
+    else:
+        current_state = "今日已生成日程，但未解析到当前时间点；不要主动编造具体状态"
 
-    return f"""
-<character_state>
-时间: {time_desc(now.hour)}
-穿着: {outfit}
-当前状态: {current_state}
-今日日程: {schedule}
-</character_state>
-<state_following_rules>
-- 当用户问到正在做什么、今天安排、所在场景、穿着或生活状态时，必须以 <character_state> 为准。
-- 不得编造与当前状态或今日日程冲突的上课、上班、外出、睡觉等状态。
-- 与用户问题无关时无需主动提及这些状态。
-</state_following_rules>"""
+    lines = [
+        "",
+        "<character_state>",
+        f"时间: {time_desc(now.hour)}",
+        f"穿着: {str(outfit or '').strip()}",
+        f"当前状态: {current_state}",
+    ]
+    if include_schedule:
+        lines.append(f"今日日程: {_clip_text(schedule, max_schedule_chars)}")
+    lines.extend(
+        [
+            "</character_state>",
+            "<state_following_rules>",
+        ]
+    )
+    if include_schedule:
+        lines.extend(
+            [
+                "- 当用户问到正在做什么、今天安排、所在场景、穿着或生活状态时，必须以 <character_state> 为准。",
+                "- 不得编造与当前状态或今日日程冲突的上课、上班、外出、睡觉等状态。",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "- 当用户问到正在做什么、所在场景、穿着或生活状态时，必须以 <character_state> 为准。",
+                "- 不得编造与当前状态冲突的上课、上班、外出、睡觉等状态。",
+                "- 若用户需要完整日程，优先调用 get_life_schedule_detail 工具查询；无法调用工具时再引导其使用“查看日程”命令。",
+            ]
+        )
+    lines.extend(
+        [
+            "- 与用户问题无关时无需主动提及这些状态。",
+            "</state_following_rules>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_life_schedule_detail(
+    date_str: str,
+    outfit_style: str,
+    outfit: str,
+    schedule: str,
+    *,
+    now: datetime.datetime | None = None,
+    business_now: datetime.datetime | None = None,
+) -> str:
+    """Build detailed life schedule text for LLM tool responses."""
+    now = now or datetime.datetime.now()
+    business_now = business_now or now
+    current_activity = select_current_activity(
+        schedule,
+        now=now,
+        wrap_previous_day=business_now.date() < now.date(),
+    )
+    current_state = current_activity or "未解析到具体时间点，请按详细日程整体保持一致"
+
+    return "\n".join(
+        [
+            "<life_schedule_detail>",
+            f"日期: {date_str}",
+            f"时间: {time_desc(now.hour)}",
+            f"穿搭风格: {str(outfit_style or '').strip() or '未指定'}",
+            f"穿着: {str(outfit or '').strip() or '未指定'}",
+            f"当前状态: {current_state}",
+            "详细日程:",
+            str(schedule or "").strip() or "无",
+            "</life_schedule_detail>",
+        ]
+    )

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import re
 from astrbot.api import logger
 from astrbot.api.all import Context, Star
 from astrbot.api.event import AstrMessageEvent, filter
+from astrbot.core.agent.message import TextPart
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.star.star_tools import StarTools
@@ -10,7 +11,12 @@ from astrbot.core.star.star_tools import StarTools
 from .core.data import ScheduleDataManager
 from .core.generator import SchedulerGenerator
 from .core.schedule import LifeScheduler
-from .core.utils import build_character_state_injection, resolve_business_now
+from .core.utils import (
+    build_character_state_injection,
+    build_life_schedule_detail,
+    life_context_injection_policy,
+    resolve_business_now,
+)
 
 
 class LifeSchedulerPlugin(Star):
@@ -64,9 +70,50 @@ class LifeSchedulerPlugin(Star):
             "timeline": [],  # 如果有 timeline 数据可以在这里添加
         }
 
+    @filter.llm_tool(name="get_life_schedule_detail")
+    async def get_life_schedule_detail(self, event: AstrMessageEvent):
+        """
+        查询当前业务日的详细生活日程、穿搭和当前状态。用户询问今天安排、完整日程、穿搭或当前生活状态时调用。
+
+        Returns:
+            string: 当前业务日的详细生活日程、穿搭和当前状态。
+        """
+        business_now = resolve_business_now(self.config.get("schedule_time"))
+        today = business_now
+        data = self.data_mgr.get(today)
+        if not data:
+            try:
+                data = await self.generator.generate_schedule(
+                    today,
+                    event.unified_msg_origin,
+                )
+            except RuntimeError:
+                return "日程正在生成中，暂时无法查询详细日程。"
+
+        if not data or data.status == "failed":
+            return "今日暂无可用日程。"
+
+        return build_life_schedule_detail(
+            today.strftime("%Y-%m-%d"),
+            data.outfit_style,
+            data.outfit,
+            data.schedule,
+            business_now=business_now,
+        )
+
     @filter.on_llm_request()
     async def on_llm_request(self, event: AstrMessageEvent, req: ProviderRequest):
-        """System Prompt 注入"""
+        """按需注入生活状态，避免每轮把完整日程塞进 system prompt。"""
+        mode = self.config.get("life_context_injection_mode", "auto")
+        request_text = self._collect_request_text(req)
+        should_inject, include_schedule = life_context_injection_policy(
+            request_text,
+            mode,
+        )
+        if not should_inject:
+            logger.debug("[LLM] 跳过生活状态注入：当前请求与日程/状态无关")
+            return
+
         business_now = resolve_business_now(self.config.get("schedule_time"))
         today = business_now
         umo = event.unified_msg_origin
@@ -83,10 +130,53 @@ class LifeSchedulerPlugin(Star):
             data.outfit,
             data.schedule,
             business_now=business_now,
+            include_schedule=include_schedule,
+            max_schedule_chars=self._config_int(
+                "life_context_max_schedule_chars",
+                1200,
+            ),
         )
 
-        req.system_prompt = (req.system_prompt or "") + inject_text
-        logger.debug(f"[LLM] 添加的内在状态注入：{inject_text}")
+        if (
+            self.config.get("life_context_injection_target", "user_prompt")
+            == "system_prompt"
+        ):
+            req.system_prompt = (req.system_prompt or "") + inject_text
+        else:
+            req.extra_user_content_parts.append(
+                TextPart(text=inject_text).mark_as_temp()
+            )
+        logger.debug(
+            "[LLM] 添加生活状态注入：mode=%s include_schedule=%s chars=%d",
+            mode,
+            include_schedule,
+            len(inject_text),
+        )
+
+    @staticmethod
+    def _collect_request_text(req: ProviderRequest) -> str:
+        if req.prompt:
+            return str(req.prompt)
+        for ctx in reversed(req.contexts or []):
+            if ctx.get("role") != "user":
+                continue
+            content = ctx.get("content")
+            if isinstance(content, str):
+                return content
+            elif isinstance(content, list):
+                parts: list[str] = []
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                if parts:
+                    return "\n".join(part for part in parts if part)
+        return ""
+
+    def _config_int(self, key: str, default: int) -> int:
+        try:
+            return int(self.config.get(key, default))
+        except (TypeError, ValueError):
+            return default
 
     @filter.command("查看日程", alias={"life show"})
     async def life_show(self, event: AstrMessageEvent):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_life_scheduler
 display_name: 拟人化生活日程
 desc: "拟人化生活日程生成插件: 利用 LLM 的能力，根据日期、节日、历史日程和近期对话记录，自动为 Bot 生成每日的穿搭和日程安排，并将其注入到系统提示词（System Prompt）中，使 Bot 拥有更加真实、连续的“生活”状态"
-version: v2.4.1
+version: v2.5.0
 author: 木有知
 repo: "https://github.com/muyouzhi6/astrbot_plugin_life_scheduler"

--- a/tests/test_scheduler_behavior.py
+++ b/tests/test_scheduler_behavior.py
@@ -42,7 +42,12 @@ _install_astrbot_stubs()
 
 from core.data import ScheduleDataManager  # noqa: E402
 from core.generator import ScheduleContext, SchedulerGenerator  # noqa: E402
-from core.utils import build_character_state_injection, select_current_activity  # noqa: E402
+from core.utils import (  # noqa: E402
+    build_character_state_injection,
+    build_life_schedule_detail,
+    life_context_injection_policy,
+    select_current_activity,
+)
 
 
 class _ConversationManager:
@@ -380,6 +385,71 @@ class SchedulerBehaviorTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("当前状态: 未解析到具体时间点", inject_text)
         self.assertIn("今日日程: 上午整理房间，下午在家看书。", inject_text)
+
+    def test_life_context_injection_policy_modes(self):
+        self.assertEqual(
+            life_context_injection_policy("随便聊聊", "off"),
+            (False, False),
+        )
+        self.assertEqual(
+            life_context_injection_policy("随便聊聊", "compact"),
+            (True, False),
+        )
+        self.assertEqual(life_context_injection_policy("随便聊聊", "full"), (True, True))
+        self.assertEqual(
+            life_context_injection_policy("随便聊聊", "auto"),
+            (False, False),
+        )
+        self.assertEqual(
+            life_context_injection_policy("你现在在做什么", "auto"),
+            (True, False),
+        )
+        self.assertEqual(
+            life_context_injection_policy("今天有什么安排", "auto"),
+            (True, False),
+        )
+
+    def test_character_state_compact_injection_skips_full_schedule(self):
+        schedule = "- 09:30 出门去咖啡店看书\n- 14:00 去逛街\n"
+        inject_text = build_character_state_injection(
+            "黑丝和吊带裙",
+            schedule,
+            now=datetime.datetime(2026, 5, 24, 9, 38),
+            include_schedule=False,
+        )
+
+        self.assertIn("当前状态: 09:30 出门去咖啡店看书", inject_text)
+        self.assertNotIn("今日日程:", inject_text)
+        self.assertIn("get_life_schedule_detail", inject_text)
+
+    def test_character_state_full_schedule_can_be_clipped(self):
+        schedule = "09:00 " + ("看书" * 20)
+        inject_text = build_character_state_injection(
+            "居家裙",
+            schedule,
+            now=datetime.datetime(2026, 5, 24, 10, 0),
+            include_schedule=True,
+            max_schedule_chars=12,
+        )
+
+        self.assertIn("今日日程: 09:00 看书看书看书...", inject_text)
+        self.assertIn("已截断", inject_text)
+
+    def test_life_schedule_detail_includes_full_schedule(self):
+        schedule = "- 09:30 出门去咖啡店看书\n- 14:00 去逛街\n"
+        detail = build_life_schedule_detail(
+            "2026-05-24",
+            "甜酷混搭风",
+            "黑丝和吊带裙",
+            schedule,
+            now=datetime.datetime(2026, 5, 24, 14, 30),
+            business_now=datetime.datetime(2026, 5, 24, 14, 30),
+        )
+
+        self.assertIn("日期: 2026-05-24", detail)
+        self.assertIn("穿搭风格: 甜酷混搭风", detail)
+        self.assertIn("当前状态: 14:00 去逛街", detail)
+        self.assertIn("详细日程:\n" + schedule.strip(), detail)
 
     async def test_manual_extra_repairs_when_output_ignores_requirement(self):
         generator, provider = self._generator(


### PR DESCRIPTION
 ## 变更内容

  - 优化日程状态注入规则，默认不再每轮把完整日程追加到
  `system_prompt`
  - 新增 `get_life_schedule_detail` LLM 工具，供模型按
  需查询当前业务日的详细日程、穿搭和当前状态
  - 默认 `auto` 策略改为只在相关对话中注入短状态，普通
  闲聊不注入，也不会触发懒生成
  - 支持配置注入策略、注入位置和完整日程截断长度
  - 更新 README、CHANGELOG，并将版本号提升到 `v2.5.0`

  ## 配置项

  - `life_context_injection_mode`: `auto` /
  `compact` / `full` / `off`
  - `life_context_injection_target`: `user_prompt` /
  `system_prompt`
  - `life_context_max_schedule_chars`: 完整日程注入时
  的最大字符数

  ## 验证

  - `python -m unittest discover -s tests -v`
  - `python -m compileall main.py core tests`
  - `git diff --check`